### PR TITLE
申请将武汉同胞求助信息列入开源信息

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,7 +25,7 @@
 * ⭐️     154         [fluttercandies/ncov_2019](https://github.com/fluttercandies/ncov_2019) 获取新肺炎实时动态App，支持Android和IOS。
 * [GuangchuangYu/nCov2019](https://github.com/GuangchuangYu/nCov2019) [query stats of infected coronavirus cases](https://mp.weixin.qq.com/s/_0D8ENb-4lGm4UV16Ok28A)
 * [canghailan/Wuhan-2019-nCoV](https://github.com/canghailan/Wuhan-2019-nCoV) 2019-nCoV 新冠状病毒 2019-12-01至今国家、省、市三级每日统计数据（支持接口读取）
-
+* [武汉同胞口罩下的呐喊](www.wuhancrisis.com) 自二月三日起微博开设的 _肺炎患者求助_ 超级话题中内累计出现过几千份来自疫区的患者求助, 网站基于[github-page](https://github.com/wuhancrisis/wuhancrisis.github.io)
 
 ### 导航网页 Navigation page
 * [wertycn/nCoV](https://github.com/wertycn/nCoV)   [2019-nCoV 武汉新冠状病毒肺炎疫情信息导航](http://nav.werty.cn/)


### PR DESCRIPTION
自二月三日, 微博开设了 肺炎患者求助 超级话题后, 该频道内累计出现过几千份来自疫区的患者求助.
笔者使用爬虫收集了能收集到的微博, 并将每个人的求助和故事整理成该网站, 所有数据均来自微博平台.